### PR TITLE
Cleanup

### DIFF
--- a/demo/traceroute.js
+++ b/demo/traceroute.js
@@ -1,5 +1,10 @@
 var el = document.getElementById('traceroute');
 
+function calcLatency(ns) {
+  let ms = ns / 1000000.0;
+  return +ms.toFixed(2) + "ms";
+};
+
 fetch('../start').then(function(resp) {
   return resp.text();
 }).then(function(body) {
@@ -21,7 +26,7 @@ fetch('../start').then(function(resp) {
   var next = document.createElement("div");
   var ih ="<h4>Route to " + data.To + "</h4><ul>";
   for (var i = 0; i < data.Route.length; i++) {
-    ih += "<li><b>" + data.Route[i].TTL +"</b> - " + data.Route[i].IP + "</li>";
+    ih += "<li><b>" + data.Route[i].TTL +"</b> - " + data.Route[i].IP + " - " + calcLatency(data.Route[i].Latency)+ "</li>";
   }
   ih += "</ul>";
   next.innerHTML = ih;

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/willscott/traas2
+
+go 1.12
+
+require github.com/google/gopacket v1.1.17

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/willscott/traas2
 
 go 1.12
 
-require github.com/google/gopacket v1.1.17
+require (
+	github.com/google/gopacket v1.1.17
+	github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/google/gopacket v1.1.17 h1:rMrlX2ZY2UbvT+sdz3+6J+pp2z+msCq9MxTU6ymxbBY=
+github.com/google/gopacket v1.1.17/go.mod h1:UdDNZ1OO62aGYVnPhxT1U6aI7ukYtA/kB8vaU0diBUM=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/google/gopacket v1.1.17 h1:rMrlX2ZY2UbvT+sdz3+6J+pp2z+msCq9MxTU6ymxbBY=
 github.com/google/gopacket v1.1.17/go.mod h1:UdDNZ1OO62aGYVnPhxT1U6aI7ukYtA/kB8vaU0diBUM=
+github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6 h1:lNCW6THrCKBiJBpz8kbVGjC7MgdCGKwuvBgc7LoD6sw=
+github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/protocol.go
+++ b/protocol.go
@@ -1,6 +1,7 @@
 package traas2
 
 import (
+	"context"
 	"net"
 	"time"
 
@@ -43,4 +44,5 @@ type Trace struct {
 	Recorded uint16 `json:"-"`
 	Route    Route
 	Hops     [TraceMaxReplies]Hop `json:"-"`
+	Cancel   context.CancelFunc   `json:"-"`
 }

--- a/protocol.go
+++ b/protocol.go
@@ -26,7 +26,9 @@ type Probe struct {
 type Hop struct {
 	TTL      uint8
 	IP       net.IP
+	Sent     time.Time `json:"-"`
 	Received time.Time
+	Latency  time.Duration
 	Packet   gopacket.Packet
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -3,6 +3,8 @@ package traas2
 import (
 	"net"
 	"time"
+
+	"github.com/google/gopacket"
 )
 
 // TraceMaxReplies indicates how many hops can be recorded for a trace.
@@ -24,6 +26,7 @@ type Hop struct {
 	TTL      uint8
 	IP       net.IP
 	Received time.Time
+	Packet   gopacket.Packet
 }
 
 // Route is a sortable list of hops

--- a/server/lib/recorder.go
+++ b/server/lib/recorder.go
@@ -108,6 +108,7 @@ func (r *Recorder) watch(incoming *gopacket.PacketSource) error {
 								continue
 							}
 							if r.debug {
+								log.Printf("Recorded expiry from %s at ttl %d.\n", ipFrame.SrcIP, v4.Id)
 								trace.Hops[trace.Recorded].Packet = packet
 							}
 							trace.Hops[trace.Recorded].IP = ipFrame.SrcIP

--- a/server/lib/recorder.go
+++ b/server/lib/recorder.go
@@ -98,8 +98,7 @@ func (r *Recorder) watch(incoming *gopacket.PacketSource) error {
 							for _, opt := range v4.Options {
 								if opt.OptionType == 7 {
 									log.Printf("route recording got us %x", opt.OptionData)
-								}
-								else if opt.OptionType == 4 {
+								} else if opt.OptionType == 4 {
 									log.Printf("timestamp got us %x", opt.OptionData)
 								}
 							}
@@ -118,7 +117,7 @@ func (r *Recorder) watch(incoming *gopacket.PacketSource) error {
 						}
 					}
 				} else {
-					log.Printf("ICMP code %d.%d received.", icmpframe.TypeCode.Type(), icmpframe.TypeCode.Code())
+					log.Printf("ICMP code %d.%d received from %s.", icmpframe.TypeCode.Type(), icmpframe.TypeCode.Code(), ipFrame.SrcIP)
 				}
 			}
 			continue

--- a/server/lib/recorder.go
+++ b/server/lib/recorder.go
@@ -115,6 +115,7 @@ func (r *Recorder) watch(incoming *gopacket.PacketSource) error {
 							trace.Hops[trace.Recorded].IP = ipFrame.SrcIP
 							trace.Hops[trace.Recorded].TTL = uint8(v4.Id)
 							trace.Hops[trace.Recorded].Received = time.Now()
+							trace.Hops[trace.Recorded].Latency = time.Now().Sub(trace.Hops[trace.Recorded].Sent) / 2
 							trace.Recorded++
 						}
 					}
@@ -144,7 +145,7 @@ func (r *Recorder) watch(incoming *gopacket.PacketSource) error {
 				}
 
 				ctx, cancel := context.WithCancel(context.Background())
-				go SpoofProbe(ctx, r.probe, packet, true)
+				go SpoofProbe(ctx, r.probe, packet, trace, true)
 
 				trace.Cancel = cancel
 				trace.Sent = time.Now()

--- a/server/lib/server.go
+++ b/server/lib/server.go
@@ -70,35 +70,20 @@ func (s *Server) EndHandler(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, s.config.Path+"/error", 302)
 		return
 	}
-	closeNotifier, ok := w.(http.CloseNotifier)
-	if !ok {
-		http.Redirect(w, r, s.config.Path+"/error", 302)
-	}
 
 	if t := s.recorder.GetTrace(ip); t != nil {
-		// Wait an extra second for the trace to get filled in.
-		delayTime := time.Millisecond * 100 * time.Duration(traas2.TraceLongestTTL-traas2.TraceShortestTTL+1)
-		select {
-		case <-time.After(delayTime):
-			t = s.recorder.GetTrace(ip)
-			if t == nil {
-				return
-			}
-			s.recorder.EndTrace(ip)
-			//sort and create route from recorded hops.
-			hops := make(traas2.Route, t.Recorded)
-			for i := uint16(0); i < t.Recorded; i++ {
-				hops[i] = t.Hops[i]
-			}
-			sort.Sort(hops)
-			t.Route = hops
+		s.recorder.EndTrace(ip)
+		//sort and create route from recorded hops.
+		hops := make(traas2.Route, t.Recorded)
+		for i := uint16(0); i < t.Recorded; i++ {
+			hops[i] = t.Hops[i]
+		}
+		sort.Sort(hops)
+		t.Route = hops
 
-			if b, err := json.Marshal(t); err == nil {
-				w.Write(b)
-				s.config.TraceLog.Println(string(b))
-			}
-		case <-closeNotifier.CloseNotify():
-			return
+		if b, err := json.Marshal(t); err == nil {
+			w.Write(b)
+			s.config.TraceLog.Println(string(b))
 		}
 	}
 }

--- a/server/lib/server.go
+++ b/server/lib/server.go
@@ -32,6 +32,7 @@ type Config struct {
 	Dst        string      // Ethernet address of the gateway network interface
 	IPHeader   string      // If client ips should be checked from e.g. an x-forwarded-for header
 	TraceFile  string      // file to log traces.
+	Debug      bool        // If diagnostic debugging should be enabled
 	TraceLog   *log.Logger `json:"-"`
 }
 
@@ -137,7 +138,7 @@ func NewServer(conf Config) *Server {
 	probe := &traas2.Probe{
 		Payload: []byte(redirect),
 	}
-	recorder, err := MakeRecorder(conf.Device, conf.Path, conf.ListenPort, probe)
+	recorder, err := MakeRecorder(conf.Device, conf.Path, conf.ListenPort, probe, conf.Debug)
 	if err != nil {
 		return nil
 	}

--- a/server/lib/spoofer.go
+++ b/server/lib/spoofer.go
@@ -47,9 +47,16 @@ func SetupSpoofingSockets(config Config) error {
 	return nil
 }
 
+func getRecordRoute() []byte {
+	route := make([]byte, 30)
+	// pointer
+	route[0] = 4
+
+	return route
+}
 func getTimestamp() []byte {
 	// per http://www.networksorcery.com/enp/protocol/ip/option004.htm
-	singleStamp := []byte{0xC4, 0x0C, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	singleStamp := []byte{0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 
 	return singleStamp
 }
@@ -74,11 +81,11 @@ func SpoofTCPMessage(src net.IP, dest net.IP, request *layers.TCP, requestLength
 		Options: []layers.IPv4Option{layers.IPv4Option{
 			OptionType:   7,
 			OptionLength: 32,
-			OptionData:   make([]byte, 30),
+			OptionData:   getRecordRoute(),
 		},
 			layers.IPv4Option{
 				OptionType:   4,
-				OptionLength: 96,
+				OptionLength: 12,
 				OptionData:   getTimestamp(),
 			}},
 	}

--- a/server/lib/spoofer.go
+++ b/server/lib/spoofer.go
@@ -131,7 +131,9 @@ func SpoofProbe(ctx context.Context, probe *traas2.Probe, inReplyTo gopacket.Pac
 		case <-ctx.Done():
 			return
 		default:
-			SpoofTCPMessage(ipFrame.DstIP, ipFrame.SrcIP, tcpFrame, uint16(len(tcpFrame.Payload)), byte(i), probe.Payload)
+			if err := SpoofTCPMessage(ipFrame.DstIP, ipFrame.SrcIP, tcpFrame, uint16(len(tcpFrame.Payload)), byte(i), probe.Payload); err != nil {
+				log.Printf("Failed to send Pkt: %v\n", err)
+			}
 			SpoofTCPMessage(ipFrame.DstIP, ipFrame.SrcIP, tcpFrame, uint16(len(tcpFrame.Payload)), byte(i+1), probe.Payload)
 			if withDelay {
 				time.Sleep(100 * time.Millisecond)

--- a/server/lib/spoofer.go
+++ b/server/lib/spoofer.go
@@ -116,7 +116,7 @@ func SpoofTCPMessage(src net.IP, dest net.IP, request *layers.TCP, requestLength
 	}
 
 	if trace != nil {
-		trace.Hops[ttl].Sent = time.Now()
+		trace.Hops[ttl-traas2.TraceShortestTTL].Sent = time.Now()
 	}
 	return SpoofIPv4Message(buf.Bytes())
 }

--- a/server/lib/spoofer.go
+++ b/server/lib/spoofer.go
@@ -91,7 +91,9 @@ func SpoofTCPMessage(src net.IP, dest net.IP, request *layers.TCP, requestLength
 		ACK:     true,
 		Window:  122,
 	}
-	tcp.SetNetworkLayerForChecksum(ip)
+	if err := tcp.SetNetworkLayerForChecksum(ip); err != nil {
+		return err
+	}
 	if err := gopacket.SerializeLayers(buf, opts, ip, tcp, gopacket.Payload(payload)); err != nil {
 		return err
 	}

--- a/server/lib/spoofer.go
+++ b/server/lib/spoofer.go
@@ -134,7 +134,6 @@ func SpoofProbe(ctx context.Context, probe *traas2.Probe, inReplyTo gopacket.Pac
 			if err := SpoofTCPMessage(ipFrame.DstIP, ipFrame.SrcIP, tcpFrame, uint16(len(tcpFrame.Payload)), byte(i), probe.Payload); err != nil {
 				log.Printf("Failed to send Pkt: %v\n", err)
 			}
-			SpoofTCPMessage(ipFrame.DstIP, ipFrame.SrcIP, tcpFrame, uint16(len(tcpFrame.Payload)), byte(i+1), probe.Payload)
 			if withDelay {
 				time.Sleep(100 * time.Millisecond)
 			}

--- a/server/lib/spoofer.go
+++ b/server/lib/spoofer.go
@@ -46,6 +46,13 @@ func SetupSpoofingSockets(config Config) error {
 	return nil
 }
 
+func getTimestamp() []byte {
+	// per http://www.networksorcery.com/enp/protocol/ip/option004.htm
+	singleStamp := []byte{0xC4, 0x0C, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+	return singleStamp
+}
+
 // SpoofTCPMessage constructs and sends a tcp message sent in the same stream as 'request' with a specified payload.
 func SpoofTCPMessage(src net.IP, dest net.IP, request *layers.TCP, requestLength uint16, ttl byte, payload []byte) error {
 	// Send legit packet.
@@ -67,7 +74,12 @@ func SpoofTCPMessage(src net.IP, dest net.IP, request *layers.TCP, requestLength
 			OptionType:   7,
 			OptionLength: 32,
 			OptionData:   make([]byte, 30),
-		}},
+		},
+			layers.IPv4Option{
+				OptionType:   4,
+				OptionLength: 96,
+				OptionData:   getTimestamp(),
+			}},
 	}
 	tcp := &layers.TCP{
 		SrcPort: request.DstPort,

--- a/server/lib/spoofer.go
+++ b/server/lib/spoofer.go
@@ -63,6 +63,11 @@ func SpoofTCPMessage(src net.IP, dest net.IP, request *layers.TCP, requestLength
 		SrcIP:    src,
 		DstIP:    dest,
 		Flags:    layers.IPv4DontFragment,
+		Options: []layers.IPv4Option{layers.IPv4Option{
+			OptionType:   7,
+			OptionLength: 32,
+			OptionData:   make([]byte, 30),
+		}},
 	}
 	tcp := &layers.TCP{
 		SrcPort: request.DstPort,

--- a/server/lib/spoofer_test.go
+++ b/server/lib/spoofer_test.go
@@ -27,7 +27,7 @@ func TestProbe(t *testing.T) {
 		SrcPort: 8080,
 	}
 
-	err := SpoofTCPMessage(host, host, tcp, 512, 64, []byte(payload))
+	err := SpoofTCPMessage(host, host, tcp, 512, 64, []byte(payload), nil)
 	if err != nil {
 		t.Fatalf("Failed to spoof msg: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestProbe(t *testing.T) {
 	serializer := gopacket.NewSerializeBuffer()
 	gopacket.SerializeLayers(serializer, gopacket.SerializeOptions{FixLengths: true}, ip, tcp)
 	pkt := gopacket.NewPacket(serializer.Bytes(), layers.LayerTypeIPv4, gopacket.DecodeOptions{})
-	SpoofProbe(context.Background(), &traas2.Probe{Payload: []byte(payload)}, pkt, false)
+	SpoofProbe(context.Background(), &traas2.Probe{Payload: []byte(payload)}, pkt, nil, false)
 
 	// Non-blocking read of the channel to see if an immediate packet was sent.
 	select {

--- a/server/lib/spoofer_test.go
+++ b/server/lib/spoofer_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"net"
 	"testing"
 
@@ -45,7 +46,7 @@ func TestProbe(t *testing.T) {
 	serializer := gopacket.NewSerializeBuffer()
 	gopacket.SerializeLayers(serializer, gopacket.SerializeOptions{FixLengths: true}, ip, tcp)
 	pkt := gopacket.NewPacket(serializer.Bytes(), layers.LayerTypeIPv4, gopacket.DecodeOptions{})
-	SpoofProbe(&traas2.Probe{Payload: []byte(payload)}, pkt, false)
+	SpoofProbe(context.Background(), &traas2.Probe{Payload: []byte(payload)}, pkt, false)
 
 	// Non-blocking read of the channel to see if an immediate packet was sent.
 	select {

--- a/server/main.go
+++ b/server/main.go
@@ -23,7 +23,7 @@ var (
 	device       = flag.String("device", "eth0", "inet device for pcap to use")
 	dstMAC       = flag.String("dstMAC", "000000000000", "Ethernet DST for sending")
 	originHeader = flag.String("originHeader", "", "Client IPs are forwarded in a http header")
-	debug        = flag.Bool("debug", false, "if true, full received packets are saved")
+	debug        = flag.Bool("debug", false, "track additional diagnostic information")
 	logFile      = flag.String("log", "", "where to log completed traces. If not set, will log to stdout")
 )
 
@@ -56,7 +56,6 @@ func main() {
 			Device:     *device,
 			Dst:        *dstMAC,
 			TraceFile:  *logFile,
-			Debug:      *debug,
 		})
 		if _, err := configHandle.Write(defaultConfig); err != nil {
 			log.Fatalf("Failed to write default config: %s", err)
@@ -106,6 +105,9 @@ func main() {
 		} else {
 			config.Device = "eth0"
 		}
+	}
+	if *debug {
+		config.Debug = true
 	}
 
 	fmt.Printf("Using config %+v \n", config)

--- a/server/main.go
+++ b/server/main.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/willscott/traas2/server/lib"
+	server "github.com/willscott/traas2/server/lib"
 )
 
 var (
@@ -23,6 +23,7 @@ var (
 	device       = flag.String("device", "eth0", "inet device for pcap to use")
 	dstMAC       = flag.String("dstMAC", "000000000000", "Ethernet DST for sending")
 	originHeader = flag.String("originHeader", "", "Client IPs are forwarded in a http header")
+	debug        = flag.Bool("debug", false, "if true, full received packets are saved")
 	logFile      = flag.String("log", "", "where to log completed traces. If not set, will log to stdout")
 )
 
@@ -55,6 +56,7 @@ func main() {
 			Device:     *device,
 			Dst:        *dstMAC,
 			TraceFile:  *logFile,
+			Debug:      *debug,
 		})
 		if _, err := configHandle.Write(defaultConfig); err != nil {
 			log.Fatalf("Failed to write default config: %s", err)


### PR DESCRIPTION
* probes are canceled early once TTL is discovered
* latency is tracked, and a timestamp TCP option is used
* updated to newer go modules
* partial support for holding onto raw packet data when doing experimental debugging